### PR TITLE
Add `relList` feature detection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,9 @@
     return {
       'Offline Capabilities': 'caches' in win,
       'Push Notifications': 'pushManager' in registration,
-      'Add to Home Screen': doc.createElement('link').relList.supports(
-          'manifest') && 'onbeforeinstallprompt' in win,
+      'Add to Home Screen': 'relList' in HTMLLinkElement.prototype &&
+          doc.createElement('link').relList.supports('manifest') &&
+          'onbeforeinstallprompt' in win,
       'Background Sync': 'sync' in registration,
       'Navigation Preload': 'navigationPreload' in registration,
       'Silent Push': 'budget' in nav && 'reserve' in nav.budget,


### PR DESCRIPTION
Seems some browsers don't support the `relList` property, so the "Add to Home Screen" detection throws an exception.